### PR TITLE
rubinius 2.5.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,9 +35,9 @@ ENV LC_ALL en_US.UTF-8
 # download & install
 RUN gem install bundler
 WORKDIR /usr/local/src
-RUN wget --quiet http://releases.rubini.us/rubinius-2.5.2.tar.bz2 && \
-  tar jxf rubinius-2.5.2.tar.bz2
-WORKDIR /usr/local/src/rubinius-2.5.2
+RUN wget --quiet http://releases.rubini.us/rubinius-2.5.3.tar.bz2 && \
+  tar jxf rubinius-2.5.3.tar.bz2
+WORKDIR /usr/local/src/rubinius-2.5.3
 RUN curl -fsSL curl.haxx.se/ca/cacert.pem -o ./library/rubygems/ssl_certs/cacert.pem
 RUN bundle
 RUN ./configure --prefix=/usr/local/rbx --libc=/usr/lib/x86_64-linux-gnu/libc
@@ -45,7 +45,7 @@ RUN rake install
 RUN /usr/local/rbx/bin/gem install --no-document bundler
 
 # cleanup
-RUN rm -rf /usr/local/src/rubinius-2.5.2.tar.bz2 && \
+RUN rm -rf /usr/local/src/rubinius-2.5.3.tar.bz2 && \
   rm -rf /var/lib/apt/lists/* && \
   rm -rf /tmp/* && \
   rm -rf /var/tmp/*

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Use the Trusted Image
 
 ```
-sudo docker run -i -t hopsoft/ruby-rbx:2.5.2 bash
+sudo docker run -i -t hopsoft/ruby-rbx:2.5.3 bash
 ruby -v
 ```
 


### PR DESCRIPTION
Simple enough upgrade to 2.5.3.

Rubinius release log is [here](https://github.com/rubinius/rubinius/releases/tag/v2.5.3)

There's an update to the internal fork() mechanism which was hitting me pretty bad when using mini_magick on sidekiq.
